### PR TITLE
Add docker setup for Symfony API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+storage/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Siroko Cart and Checkout Example
+
+This repository provides three small projects:
+
+1. `cart-api`: a domain-driven example API for managing the shopping cart and checkout.
+2. `symfony-api`: a lightweight Symfony 6 style API that exposes basic cart endpoints.
+3. `next-app`: a simple Next.js frontend that interacts with the API.
+
+All projects are intentionally minimal to avoid external dependencies in this environment.
+
+## Running the PHP APIs with Docker
+
+Both APIs target PHP 8, so the easiest way to run them is via Docker.
+
+### Cart API
+
+```bash
+cd cart-api
+docker-compose up
+```
+
+### Symfony API
+
+```bash
+cd symfony-api
+docker-compose up
+```
+
+If you prefer to run the Symfony example locally, install its dependencies first *(requires internet)*:
+
+```bash
+composer install
+php -S localhost:8080 -t public
+```
+
+## Running the Frontend
+
+1. From the `next-app` folder, install dependencies *(requires internet)*: `npm install`.
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+Navigate to `http://localhost:3000` to use the frontend.

--- a/cart-api/Dockerfile
+++ b/cart-api/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:8.2-cli
+WORKDIR /app
+COPY . /app
+CMD ["php", "-S", "0.0.0.0:8080", "-t", "public"]

--- a/cart-api/README.md
+++ b/cart-api/README.md
@@ -1,0 +1,49 @@
+# Siroko Cart API
+
+API minimal para gestionar el carrito y procesar el pago en la tienda Siroko. El dominio est\u00E1 desacoplado de la capa HTTP.
+
+## Tecnolog\u00EDa
+
+- PHP 8.2 (sin dependencias externas por limitaciones del entorno)
+- Arquitectura inspirada en DDD y Hexagonal
+- CQRS aplicado con comandos y consultas simples
+
+## Modelado del Dominio
+
+- **Product**: identificador, nombre y precio.
+- **Cart**: agregado con l\u00EDnea de productos.
+- **Order**: se genera al confirmar la compra.
+- Repositorios abstra\u00EDdos mediante interfaces y almacenados en ficheros.
+
+## OpenAPI
+
+La especificaci\u00F3n se encuentra en `docs/openapi.yaml`.
+
+## Puesta en marcha
+
+1. Requiere Docker.
+2. Ejecutar:
+
+```bash
+docker-compose up
+```
+
+3. La API quedar\u00E1 disponible en `http://localhost:8080`.
+
+### Endpoints principales
+
+- `GET /cart` Obtener el carrito.
+- `POST /cart/items` A\u00F1adir producto al carrito.
+- `PUT /cart/items/{productId}` Actualizar cantidad.
+- `DELETE /cart/items/{productId}` Eliminar producto.
+- `POST /checkout` Procesar pago y generar orden.
+
+## Tests
+
+Se incluyen pruebas de ejemplo en `tests/`. Para ejecutarlas:
+
+```bash
+php tests/CartTest.php
+```
+
+Debido a las restricciones de este entorno, no se han podido a\u00F1adir m\u00F3dulos externos ni ejecutar phpunit.

--- a/cart-api/docker-compose.yml
+++ b/cart-api/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/app

--- a/cart-api/docs/openapi.yaml
+++ b/cart-api/docs/openapi.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.0
+info:
+  title: Siroko Cart API
+  version: '1.0'
+paths:
+  /cart:
+    get:
+      summary: Obtener el carrito
+      responses:
+        '200':
+          description: Estado del carrito
+  /cart/items:
+    post:
+      summary: A\u00F1adir producto al carrito
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                product_id:
+                  type: string
+                quantity:
+                  type: integer
+      responses:
+        '200': {description: Item added}
+  /cart/items/{productId}:
+    put:
+      summary: Actualizar cantidad de producto
+      parameters:
+        - in: path
+          name: productId
+          required: true
+          schema: {type: string}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                quantity:
+                  type: integer
+      responses:
+        '200': {description: Updated}
+    delete:
+      summary: Eliminar producto del carrito
+      parameters:
+        - in: path
+          name: productId
+          required: true
+          schema: {type: string}
+      responses:
+        '200': {description: Deleted}
+  /checkout:
+    post:
+      summary: Procesar el pago y crear la orden
+      responses:
+        '200':
+          description: Orden creada

--- a/cart-api/public/index.php
+++ b/cart-api/public/index.php
@@ -1,0 +1,81 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use App\Application\Command\AddItemToCartCommand;
+use App\Application\Command\CheckoutCommand;
+use App\Application\Command\RemoveItemFromCartCommand;
+use App\Application\Command\UpdateItemQuantityCommand;
+use App\Application\Handler\AddItemToCartHandler;
+use App\Application\Handler\CheckoutHandler;
+use App\Application\Handler\GetCartHandler;
+use App\Application\Handler\RemoveItemFromCartHandler;
+use App\Application\Handler\UpdateItemQuantityHandler;
+use App\Application\Query\GetCartQuery;
+use App\Infrastructure\Persistence\FileCartRepository;
+use App\Infrastructure\Persistence\FileOrderRepository;
+use App\Infrastructure\Persistence\InMemoryProductRepository;
+
+$products = new InMemoryProductRepository();
+$carts = new FileCartRepository($products, __DIR__.'/../storage/cart.json');
+$orders = new FileOrderRepository(__DIR__.'/../storage/orders.json');
+
+$addItem = new AddItemToCartHandler($carts, $products);
+$updateItem = new UpdateItemQuantityHandler($carts);
+$removeItem = new RemoveItemFromCartHandler($carts);
+$getCart = new GetCartHandler($carts);
+$checkout = new CheckoutHandler($carts, $orders);
+
+$method = $_SERVER['REQUEST_METHOD'];
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+header('Content-Type: application/json');
+
+function send($data, int $code = 200): void
+{
+    http_response_code($code);
+    echo json_encode($data);
+    exit;
+}
+
+if ($method === 'POST' && $path === '/cart/items') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $command = new AddItemToCartCommand($data['product_id'], $data['quantity'] ?? 1);
+    $addItem($command);
+    send(['status' => 'ok']);
+}
+
+if ($method === 'PUT' && preg_match('#^/cart/items/(?P<id>[^/]+)$#', $path, $m)) {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $command = new UpdateItemQuantityCommand($m['id'], $data['quantity']);
+    $updateItem($command);
+    send(['status' => 'ok']);
+}
+
+if ($method === 'DELETE' && preg_match('#^/cart/items/(?P<id>[^/]+)$#', $path, $m)) {
+    $command = new RemoveItemFromCartCommand($m['id']);
+    $removeItem($command);
+    send(['status' => 'ok']);
+}
+
+if ($method === 'GET' && $path === '/cart') {
+    $cart = $getCart(new GetCartQuery());
+    $items = [];
+    foreach ($cart->items() as $item) {
+        $items[] = [
+            'product_id' => $item->product()->id(),
+            'name' => $item->product()->name(),
+            'price' => $item->product()->price(),
+            'quantity' => $item->quantity(),
+            'subtotal' => $item->subtotal()
+        ];
+    }
+    send(['items' => $items, 'total' => $cart->total()]);
+}
+
+if ($method === 'POST' && $path === '/checkout') {
+    $order = $checkout(new CheckoutCommand());
+    send(['order_id' => $order->id(), 'total' => $order->total()]);
+}
+
+send(['error' => 'Not Found'], 404);

--- a/cart-api/src/Application/Command/AddItemToCartCommand.php
+++ b/cart-api/src/Application/Command/AddItemToCartCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Application\Command;
+
+class AddItemToCartCommand
+{
+    public function __construct(
+        public readonly string $productId,
+        public readonly int $quantity
+    ) {
+    }
+}

--- a/cart-api/src/Application/Command/CheckoutCommand.php
+++ b/cart-api/src/Application/Command/CheckoutCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Application\Command;
+
+class CheckoutCommand
+{
+    public function __construct()
+    {
+    }
+}

--- a/cart-api/src/Application/Command/RemoveItemFromCartCommand.php
+++ b/cart-api/src/Application/Command/RemoveItemFromCartCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Application\Command;
+
+class RemoveItemFromCartCommand
+{
+    public function __construct(public readonly string $productId)
+    {
+    }
+}

--- a/cart-api/src/Application/Command/UpdateItemQuantityCommand.php
+++ b/cart-api/src/Application/Command/UpdateItemQuantityCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Application\Command;
+
+class UpdateItemQuantityCommand
+{
+    public function __construct(
+        public readonly string $productId,
+        public readonly int $quantity
+    ) {
+    }
+}

--- a/cart-api/src/Application/Handler/AddItemToCartHandler.php
+++ b/cart-api/src/Application/Handler/AddItemToCartHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Application\Handler;
+
+use App\Application\Command\AddItemToCartCommand;
+use App\Domain\Repository\CartRepositoryInterface;
+use App\Domain\Repository\ProductRepositoryInterface;
+
+class AddItemToCartHandler
+{
+    public function __construct(
+        private CartRepositoryInterface $carts,
+        private ProductRepositoryInterface $products
+    ) {
+    }
+
+    public function __invoke(AddItemToCartCommand $command): void
+    {
+        $cart = $carts = $this->carts->get();
+        $product = $this->products->find($command->productId);
+        if (!$product) {
+            throw new \InvalidArgumentException('Product not found');
+        }
+        $cart->addItem($product, $command->quantity);
+        $this->carts->save($cart);
+    }
+}

--- a/cart-api/src/Application/Handler/CheckoutHandler.php
+++ b/cart-api/src/Application/Handler/CheckoutHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Application\Handler;
+
+use App\Application\Command\CheckoutCommand;
+use App\Domain\Entity\Order;
+use App\Domain\Repository\CartRepositoryInterface;
+use App\Domain\Repository\OrderRepositoryInterface;
+
+class CheckoutHandler
+{
+    public function __construct(
+        private CartRepositoryInterface $carts,
+        private OrderRepositoryInterface $orders
+    ) {
+    }
+
+    public function __invoke(CheckoutCommand $command): Order
+    {
+        $cart = $this->carts->get();
+        $order = new Order(uniqid('order_'), $cart->items(), $cart->total());
+        $this->orders->save($order);
+        // Reset cart
+        $this->carts->save(new \App\Domain\Entity\Cart($cart->id()));
+        return $order;
+    }
+}

--- a/cart-api/src/Application/Handler/GetCartHandler.php
+++ b/cart-api/src/Application/Handler/GetCartHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Application\Handler;
+
+use App\Application\Query\GetCartQuery;
+use App\Domain\Repository\CartRepositoryInterface;
+use App\Domain\Entity\Cart;
+
+class GetCartHandler
+{
+    public function __construct(private CartRepositoryInterface $carts)
+    {
+    }
+
+    public function __invoke(GetCartQuery $query): Cart
+    {
+        return $this->carts->get();
+    }
+}

--- a/cart-api/src/Application/Handler/RemoveItemFromCartHandler.php
+++ b/cart-api/src/Application/Handler/RemoveItemFromCartHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Application\Handler;
+
+use App\Application\Command\RemoveItemFromCartCommand;
+use App\Domain\Repository\CartRepositoryInterface;
+
+class RemoveItemFromCartHandler
+{
+    public function __construct(private CartRepositoryInterface $carts)
+    {
+    }
+
+    public function __invoke(RemoveItemFromCartCommand $command): void
+    {
+        $cart = $this->carts->get();
+        $cart->removeItem($command->productId);
+        $this->carts->save($cart);
+    }
+}

--- a/cart-api/src/Application/Handler/UpdateItemQuantityHandler.php
+++ b/cart-api/src/Application/Handler/UpdateItemQuantityHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Application\Handler;
+
+use App\Application\Command\UpdateItemQuantityCommand;
+use App\Domain\Repository\CartRepositoryInterface;
+
+class UpdateItemQuantityHandler
+{
+    public function __construct(private CartRepositoryInterface $carts)
+    {
+    }
+
+    public function __invoke(UpdateItemQuantityCommand $command): void
+    {
+        $cart = $this->carts->get();
+        $cart->updateItem($command->productId, $command->quantity);
+        $this->carts->save($cart);
+    }
+}

--- a/cart-api/src/Application/Query/GetCartQuery.php
+++ b/cart-api/src/Application/Query/GetCartQuery.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Application\Query;
+
+class GetCartQuery
+{
+    // Query without parameters (single cart)
+}

--- a/cart-api/src/Domain/Entity/Cart.php
+++ b/cart-api/src/Domain/Entity/Cart.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Domain\Entity;
+
+class Cart
+{
+    /** @var CartItem[] */
+    private array $items = [];
+
+    public function __construct(private string $id)
+    {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function items(): array
+    {
+        return array_values($this->items);
+    }
+
+    public function addItem(Product $product, int $quantity): void
+    {
+        if (isset($this->items[$product->id()])) {
+            $this->items[$product->id()]->increaseQuantity($quantity);
+        } else {
+            $this->items[$product->id()] = new CartItem($product, $quantity);
+        }
+    }
+
+    public function updateItem(string $productId, int $quantity): void
+    {
+        if (!isset($this->items[$productId])) {
+            return;
+        }
+        if ($quantity <= 0) {
+            unset($this->items[$productId]);
+        } else {
+            $this->items[$productId]->setQuantity($quantity);
+        }
+    }
+
+    public function removeItem(string $productId): void
+    {
+        unset($this->items[$productId]);
+    }
+
+    public function total(): float
+    {
+        return array_reduce($this->items, fn($sum, CartItem $i) => $sum + $i->subtotal(), 0.0);
+    }
+}

--- a/cart-api/src/Domain/Entity/CartItem.php
+++ b/cart-api/src/Domain/Entity/CartItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Domain\Entity;
+
+class CartItem
+{
+    public function __construct(
+        private Product $product,
+        private int $quantity
+    ) {
+    }
+
+    public function product(): Product
+    {
+        return $this->product;
+    }
+
+    public function quantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function increaseQuantity(int $amount): void
+    {
+        $this->quantity += $amount;
+    }
+
+    public function setQuantity(int $quantity): void
+    {
+        $this->quantity = $quantity;
+    }
+
+    public function subtotal(): float
+    {
+        return $this->product->price() * $this->quantity;
+    }
+}

--- a/cart-api/src/Domain/Entity/Order.php
+++ b/cart-api/src/Domain/Entity/Order.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Domain\Entity;
+
+class Order
+{
+    public function __construct(
+        private string $id,
+        private array $items,
+        private float $total
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function items(): array
+    {
+        return $this->items;
+    }
+
+    public function total(): float
+    {
+        return $this->total;
+    }
+}

--- a/cart-api/src/Domain/Entity/Product.php
+++ b/cart-api/src/Domain/Entity/Product.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Domain\Entity;
+
+class Product
+{
+    public function __construct(
+        private string $id,
+        private string $name,
+        private float $price
+    ) {
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function price(): float
+    {
+        return $this->price;
+    }
+}

--- a/cart-api/src/Domain/Repository/CartRepositoryInterface.php
+++ b/cart-api/src/Domain/Repository/CartRepositoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Domain\Repository;
+
+use App\Domain\Entity\Cart;
+
+interface CartRepositoryInterface
+{
+    public function get(): Cart;
+    public function save(Cart $cart): void;
+}

--- a/cart-api/src/Domain/Repository/OrderRepositoryInterface.php
+++ b/cart-api/src/Domain/Repository/OrderRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\Repository;
+
+use App\Domain\Entity\Order;
+
+interface OrderRepositoryInterface
+{
+    public function save(Order $order): void;
+}

--- a/cart-api/src/Domain/Repository/ProductRepositoryInterface.php
+++ b/cart-api/src/Domain/Repository/ProductRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\Repository;
+
+use App\Domain\Entity\Product;
+
+interface ProductRepositoryInterface
+{
+    public function find(string $id): ?Product;
+}

--- a/cart-api/src/Infrastructure/Persistence/FileCartRepository.php
+++ b/cart-api/src/Infrastructure/Persistence/FileCartRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Infrastructure\Persistence;
+
+use App\Domain\Entity\Cart;
+use App\Domain\Entity\Product;
+use App\Domain\Repository\CartRepositoryInterface;
+use App\Domain\Repository\ProductRepositoryInterface;
+
+class FileCartRepository implements CartRepositoryInterface
+{
+    private string $file;
+
+    public function __construct(private ProductRepositoryInterface $products, string $file)
+    {
+        $this->file = $file;
+    }
+
+    public function get(): Cart
+    {
+        if (!file_exists($this->file)) {
+            return new Cart('default');
+        }
+        $data = json_decode(file_get_contents($this->file), true);
+        $cart = new Cart($data['id']);
+        foreach ($data['items'] as $item) {
+            $product = $this->products->find($item['product_id']);
+            if ($product) {
+                $cart->addItem($product, $item['quantity']);
+            }
+        }
+        return $cart;
+    }
+
+    public function save(Cart $cart): void
+    {
+        $data = [
+            'id' => $cart->id(),
+            'items' => []
+        ];
+        foreach ($cart->items() as $item) {
+            $data['items'][] = [
+                'product_id' => $item->product()->id(),
+                'quantity' => $item->quantity()
+            ];
+        }
+        file_put_contents($this->file, json_encode($data));
+    }
+}

--- a/cart-api/src/Infrastructure/Persistence/FileOrderRepository.php
+++ b/cart-api/src/Infrastructure/Persistence/FileOrderRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Infrastructure\Persistence;
+
+use App\Domain\Entity\Order;
+use App\Domain\Repository\OrderRepositoryInterface;
+
+class FileOrderRepository implements OrderRepositoryInterface
+{
+    private string $file;
+
+    public function __construct(string $file)
+    {
+        $this->file = $file;
+    }
+
+    public function save(Order $order): void
+    {
+        $orders = [];
+        if (file_exists($this->file)) {
+            $orders = json_decode(file_get_contents($this->file), true);
+        }
+        $orders[] = [
+            'id' => $order->id(),
+            'items' => array_map(fn($item) => [
+                'product_id' => $item->product()->id(),
+                'quantity' => $item->quantity(),
+                'price' => $item->product()->price()
+            ], $order->items()),
+            'total' => $order->total()
+        ];
+        file_put_contents($this->file, json_encode($orders));
+    }
+}

--- a/cart-api/src/Infrastructure/Persistence/InMemoryProductRepository.php
+++ b/cart-api/src/Infrastructure/Persistence/InMemoryProductRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Infrastructure\Persistence;
+
+use App\Domain\Entity\Product;
+use App\Domain\Repository\ProductRepositoryInterface;
+
+class InMemoryProductRepository implements ProductRepositoryInterface
+{
+    /** @var Product[] */
+    private array $products = [];
+
+    public function __construct()
+    {
+        $this->products = [
+            new Product('p1', 'Maillot', 35.0),
+            new Product('p2', 'Culotte', 50.0),
+            new Product('p3', 'Gafas', 60.0),
+        ];
+    }
+
+    public function find(string $id): ?Product
+    {
+        foreach ($this->products as $product) {
+            if ($product->id() === $id) {
+                return $product;
+            }
+        }
+        return null;
+    }
+}

--- a/cart-api/tests/CartTest.php
+++ b/cart-api/tests/CartTest.php
@@ -1,0 +1,16 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use App\Domain\Entity\Cart;
+use App\Domain\Entity\Product;
+
+$cart = new Cart('test');
+$cart->addItem(new Product('p1', 'Test', 10), 2);
+assert($cart->total() === 20.0);
+$cart->updateItem('p1', 3);
+assert($cart->total() === 30.0);
+$cart->removeItem('p1');
+assert($cart->total() === 0.0);
+
+echo "Cart tests passed\n";

--- a/cart-api/vendor/autoload.php
+++ b/cart-api/vendor/autoload.php
@@ -1,0 +1,12 @@
+<?php
+spl_autoload_register(function($class) {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../src/';
+    if (str_starts_with($class, $prefix)) {
+        $relative = substr($class, strlen($prefix));
+        $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    }
+});

--- a/next-app/README.md
+++ b/next-app/README.md
@@ -1,0 +1,16 @@
+# Next.js Frontend
+
+This frontend is a minimal example built with Next.js. It communicates with the Symfony API located in `symfony-api`.
+
+## Scripts
+
+- `npm run dev` – Start the development server (requires dependencies).
+- `npm run build` – Build for production.
+
+## Pages
+
+- `/` – Display cart items.
+- `/add` – Form to add an item.
+- `/checkout` – Checkout button.
+
+This example omits the dependency installation. You would normally run `npm install` to fetch packages before starting.

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "next-app",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/next-app/pages/add.js
+++ b/next-app/pages/add.js
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+
+export default function Add() {
+  const [product, setProduct] = useState('')
+  const [qty, setQty] = useState(1)
+
+  const submit = async e => {
+    e.preventDefault()
+    await fetch('http://localhost:8080/cart/add', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ product, qty: parseInt(qty) })
+    })
+    setProduct('')
+    setQty(1)
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <input value={product} onChange={e => setProduct(e.target.value)} placeholder='product'/>
+      <input type='number' value={qty} onChange={e => setQty(e.target.value)} />
+      <button type='submit'>Add</button>
+    </form>
+  )
+}

--- a/next-app/pages/checkout.js
+++ b/next-app/pages/checkout.js
@@ -1,0 +1,11 @@
+export default function Checkout() {
+  const doCheckout = async () => {
+    const res = await fetch('http://localhost:8080/checkout', { method: 'POST' })
+    const data = await res.json()
+    alert('Order total: ' + data.order.total)
+  }
+
+  return (
+    <button onClick={doCheckout}>Checkout</button>
+  )
+}

--- a/next-app/pages/index.js
+++ b/next-app/pages/index.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+export default function Home() {
+  const [cart, setCart] = useState([])
+
+  useEffect(() => {
+    fetch('http://localhost:8080/cart')
+      .then(res => res.json())
+      .then(data => setCart(data))
+  }, [])
+
+  return (
+    <div>
+      <h1>Cart Items</h1>
+      <ul>
+        {cart.map((item, i) => (
+          <li key={i}>{item.product} - qty {item.qty}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/symfony-api/Dockerfile
+++ b/symfony-api/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:8.2-cli
+WORKDIR /app
+COPY composer.json /app/
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-dev --prefer-dist --no-progress --no-interaction
+COPY . /app
+CMD ["php", "-S", "0.0.0.0:8080", "-t", "public"]

--- a/symfony-api/README.md
+++ b/symfony-api/README.md
@@ -1,0 +1,30 @@
+# Symfony API
+
+This is a minimal example of an API using a lightweight Symfony 6 setup. It exposes basic endpoints for managing a cart and performing a checkout.
+
+## Endpoints
+
+- `GET /cart` – Retrieve the cart contents
+- `POST /cart/add` – Add an item to the cart. JSON body: `{ "product": "id", "qty": 2 }`
+- `POST /checkout` – Perform checkout and return the created order
+
+## Running
+
+The project targets PHP 8, so it is easiest to run it via Docker.
+
+1. Build and start the container with docker compose:
+   ```bash
+   docker-compose up
+   ```
+   The API will be available on `http://localhost:8080`.
+2. If you prefer to run it locally, first install the dependencies *(requires internet access)*:
+   ```bash
+   composer install
+   ```
+   Then start the built-in PHP server:
+   ```bash
+   php -S localhost:8080 -t public
+   ```
+3. Test the API using `curl` or your preferred HTTP client.
+
+This repository includes only the minimal files necessary to illustrate a Symfony-like API without relying on a full framework installation.

--- a/symfony-api/composer.json
+++ b/symfony-api/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "example/symfony-api",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "symfony/http-kernel": "^6.0",
+        "symfony/http-foundation": "^6.0",
+        "symfony/routing": "^6.0"
+    },
+    "autoload": {
+        "psr-4": {"App\\": "src/"}
+    }
+}

--- a/symfony-api/docker-compose.yml
+++ b/symfony-api/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/app

--- a/symfony-api/public/index.php
+++ b/symfony-api/public/index.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing;
+use Symfony\Component\HttpKernel;
+
+$routes = new Routing\RouteCollection();
+$routes->add('cart_get', new Routing\Route('/cart', [
+    '_controller' => [App\Controller\CartController::class, 'get'],
+]));
+$routes->add('cart_add', new Routing\Route('/cart/add', [
+    '_controller' => [App\Controller\CartController::class, 'add'],
+]));
+$routes->add('cart_checkout', new Routing\Route('/checkout', [
+    '_controller' => [App\Controller\CartController::class, 'checkout'],
+]));
+
+$context = new Routing\RequestContext();
+$context->fromRequest(Request::createFromGlobals());
+$matcher = new Routing\Matcher\UrlMatcher($routes, $context);
+
+$controllerResolver = new HttpKernel\Controller\ControllerResolver();
+$argumentResolver = new HttpKernel\Controller\ArgumentResolver();
+
+$request = Request::createFromGlobals();
+try {
+    $request->attributes->add($matcher->match($request->getPathInfo()));
+    $controller = $controllerResolver->getController($request);
+    $arguments = $argumentResolver->getArguments($request, $controller);
+    $response = call_user_func_array($controller, $arguments);
+} catch (Routing\Exception\ResourceNotFoundException $e) {
+    $response = new Response('Not Found', 404);
+} catch (Exception $e) {
+    $response = new Response('An error occurred: '.$e->getMessage(), 500);
+}
+$response->send();

--- a/symfony-api/src/Controller/CartController.php
+++ b/symfony-api/src/Controller/CartController.php
@@ -1,0 +1,32 @@
+<?php
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class CartController
+{
+    private static array $cart = [];
+
+    public function get(): JsonResponse
+    {
+        return new JsonResponse(self::$cart);
+    }
+
+    public function add(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        self::$cart[] = [
+            'product' => $data['product'] ?? 'unknown',
+            'qty' => (int) ($data['qty'] ?? 1),
+        ];
+        return new JsonResponse(['status' => 'added']);
+    }
+
+    public function checkout(): JsonResponse
+    {
+        $order = ['items' => self::$cart, 'total' => count(self::$cart)];
+        self::$cart = [];
+        return new JsonResponse(['order' => $order]);
+    }
+}


### PR DESCRIPTION
## Summary
- containerize Symfony API so PHP 8 isn't required locally
- update instructions and root README for running both APIs via Docker

## Testing
- `php cart-api/tests/CartTest.php`
- `php -l symfony-api/public/index.php`
- `php -l cart-api/public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_688739dbeb1c8324a1af87308e29227b